### PR TITLE
Support for direct mode proxy, no support for forwarding mode proxy

### DIFF
--- a/src/RedirPlugin.cc
+++ b/src/RedirPlugin.cc
@@ -82,12 +82,12 @@ int RedirPlugin::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
   std::string rpath(path);
   rpath.erase(0, 1);
   XrdCl::URL target(rpath);
-  std::string pathLookup = target.GetPath();
+  std::string pathLookup = target.GetURL();
   size_t splitpos = pathLookup.find("/");
-  if (splitpos == string::npos)
+  if (splitpos == string::npos) 
     return SFS_ERROR;
 
-  size_t slen = pathLookup.size();
+  //size_t slen = pathLookup.size();
   XrdCl::URL proxyTarget(std::string("root://") + prefix + std::string("/x") +
                          pathLookup.substr(0, splitpos));
   int rc = 0;               // figure out exact meaning
@@ -95,7 +95,7 @@ int RedirPlugin::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
   // which must be longer than localroot and filename concatenated
   char *buff = new char[maxPathLength];
   const char *ppath =
-      theSS->Lfn2Pfn(pathLookup.substr(splitpos, slen - splitpos).c_str(), buff,
+      theSS->Lfn2Pfn(path, buff,
                      maxPathLength, rc);
 
   if (access(ppath, F_OK) == 0) { // File found


### PR DESCRIPTION
It works with direct mode proxy instead forwarding mode proxy. Root's TNetXNGFile::ReadBuffers() has problem reading files from forwarding mode proxies.

Local redirect plugin in forwarding mode proxy:
Incoming URL: root://<redirector_IP>:<redirector_port>///xroot://<remote_server>//path/to/file
Outgoing URL to forward mode proxy: root://<forwardproxy_IP>:<forwardproxy_port>///xroot://<remote_server>//path/to/file
Outgoing URL to client for local redirection: file://localhost//<oss.localroot>/path/to/file

Local redirect plugin in direct mode proxy: (kit-proj_v2)
Incoming URL: root://<redirector_IP>:<redirector_port>//path/to/file
Outgoing URL to forward mode proxy: root://<forwardproxy_IP>:<forwardproxy_port>//path/to/file
Outgoing URL to client for local redirection: file://localhost//<oss.localroot>/path/to/file
